### PR TITLE
Style guide revision to query-graph.adoc

### DIFF
--- a/modules/ROOT/pages/query-graph.adoc
+++ b/modules/ROOT/pages/query-graph.adoc
@@ -8,15 +8,15 @@ image::run-a-query.png[]
 . In the *Request access to run queries* screen, select how you want to authenticate your client to query the graph.
 +
 image::request-access-query.png[]
-<1> Select *User one of my existing applications* if you already have a client application authenticated to send requests.
-<1> Select *Create a new application and use it immediately* to create a new application to query the graph.
-<1> Select *I already have credentials and want to use them immediately* if you already have a client ID and secret pair to send requests to your graph.
+* Select the first option to use an existing authenticated client application to query the graph.
+* Select the second option to create a new application to query the graph.
+* Select the third option to use an existing client ID and secret pair to query the graph.
 . Select *Request Access*.
 . On the left side of the screen, start typing the query using the in-line autocomplete feature.
 +
 image::run-query-screen.png[]
-<1> Select *Copy Query* to copy the query your query as a GraphQL query, or as a cURL snippet.
-<1> Select *View History* to see all the queries you sent to the unified schema.
-<1> Select *Manage Credentials* to change the credentials you selected in the previous step.
-<1> Select *Explore Docs* to explore the unified schema documentation.
-. Select *Run* to send a query to the unified schema.
+* Select the first item (*Copy Query*) to copy your query as a GraphQL query or as a cURL snippet.
+* Select the second item (*View History*) to see all the queries you sent to the unified schema.
+* Select the third item (*Manage Credentials*) to change the credentials you selected in the previous step.
+* Select the fourth item (*Explore Docs*) to open the unified schema documentation.
+. Click *Run* to send a query to the unified schema.


### PR DESCRIPTION
@fermujica I made these edits based off what I saw in the screenshot guidelines for [describing annotated items](https://docs.google.com/document/d/1ozDZQVzby980ylBmk5AgIue4ETvt7tDvgVzCScDRv-Q/edit#heading=h.oqaw80hjyr8a). I'm not wild about the "Select the first option.." business. 

I wonder how necessary the annotations on the screenshots are? I didn't see any guidance that they're *mandatory*. One other thing I'd suggest is to do away with the screenshot annotations and instead use an unordered list under the screenshot, e.g.,

Select one of the following options:

- **Use one of my existing applications**: Use an existing authenticated client application to query the graph.
- **Create a new application and use it immediately**: Create a new application to query the graph.
- **I already have credentials and want to use them immediately**: Use an existing client ID and secret pair to query the graph.

And then I'd do something similar for the other section

- **Copy  Query**: Copy your query as a GraphQL query or as a cURL snippet.
- **View History**: Get a list of all the queries you've sent to the unified schema.
- **Manage Credentials**: Change the credentials you selected in the previous step.
- **Explore Docs**: Open the unified schema documentation.