### PR TITLE
DOCS-1119 Add limit of 16k fields per unified schema

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -86,6 +86,8 @@ ordersByOrderId {               #depth 0
      }
 ....
 
+* Anypoint DataGraph supports up to 16,000 fields per unified schema.
+
 == Anypoint Platform Requirements and Licensing
 
 To use Anypoint DataGraph, ensure you meet the following requirements:


### PR DESCRIPTION
DataGraph supports up to 16k fields per unified schema