### PR TITLE
DOCS-11139-cannot-change-url-after-adding-api

### DIFF
--- a/modules/ROOT/pages/add-api-to-unified-schema.adoc
+++ b/modules/ROOT/pages/add-api-to-unified-schema.adoc
@@ -34,7 +34,7 @@ The first task to adding an API to the unified schema is adding the API to Anypo
 [IMPORTANT]
 --
 * Supported authentication methods to access your API from Anypoint DataGraph are listed in the following procedure. Any other authentication methods, such as custom OAuth implementations or short-lived token methods, are not supported. See xref:supported-authentication-methods.adoc[] for more information.
-* After you add an API to Anypoint DataGraph you can't change its URL. To change an API's URL, remove the API and re-add it. You can, however, edit an API's authentication method at any time.
+* After you add an API to Anypoint DataGraph, you can't change its URL. To change an API's URL, remove the API and re-add it. You can, however, edit an API's authentication method at any time.
 --
 
 . From Anypoint Platform > Anypoint DataGraph, select the appropriate environment from the *Unified Data Graph* dropdown list, and click *+Add API*.

--- a/modules/ROOT/pages/promote-api.adoc
+++ b/modules/ROOT/pages/promote-api.adoc
@@ -30,7 +30,7 @@ You can promote API schemas to any environment to which you are permitted access
 
 Although your APIs must be published in Exchange, they do not need to be Mule applications or be running on Mule runtime engine or in CloudHub to be added to the unified schema.
 
-The schema you promote must not be in conflict with the unified schema in the target environment. If conflict exists, you must instead manually add the API and resolve those conflicts as you would when adding an API.
+The schema you promote must not be in conflict with the unified schema in the target environment. If conflicts exist, you must instead manually add the API and resolve those conflicts as you would when adding an API.
 
 You must have xref:permissions.adoc[the Contribute or Admin permission].
 


### PR DESCRIPTION
This PR adds a note that you can't change an API's URL after adding it to DataGraph. Also moves the note about supported authentication methods into the same IMPORTANT block. Using an IMPORTANT block as these issues routinely came up in field validation