### PR TITLE
[W-10592565] new callout list syntax + fix typos

### DIFF
--- a/modules/ROOT/pages/datagraph-cli-errors.adoc
+++ b/modules/ROOT/pages/datagraph-cli-errors.adoc
@@ -222,6 +222,6 @@ Conflict errors occur when you try to add an API schema to the unified schema. T
 * The `message` field contains a human-readable response of the validation and provides a summary of the error.
 * The `detail` field contains a list of all conflicts found when trying to merge the API schema into the unified schema. 
 ** The `element` field contains the location of the conflict.
-** The `violations` field lists the coflicts to fix. 
+** The `violations` field lists the conflicts to fix. 
 *** The `code` field identifies the type of the error.
 *** The `message` field contains a human-readable description of the issue, and, depending on the type of error, it can contain additional properties with more details.

--- a/modules/ROOT/pages/datagraph-qsg.adoc
+++ b/modules/ROOT/pages/datagraph-qsg.adoc
@@ -330,13 +330,14 @@ Now you can write a query to retrieve specific information about the order you c
 Notice that with this one query, you get results from two different APIs:
 +
 image::datagraph-qsg-two-apis.png[Two APIs are being queried from a single query]
-+
+
 [calloutlist]
 . `shippingAddress`, `total`, and `status` information is returned from the Catalyst Order API
 . `product` details is returned as part of the `shipmentItems` information from the Catalyst Product API
 +
 This is the fundamental utility of Anypoint DataGraph: the ability to query multiple APIs in a single request to get only the information you want.
 
+[start=2]
 . To run the query without query tracing, click *Run*:
 +
 image::datagraph-qsg-query-result.png[Query editor displays query results]

--- a/modules/ROOT/pages/datagraph-qsg.adoc
+++ b/modules/ROOT/pages/datagraph-qsg.adoc
@@ -331,8 +331,9 @@ Notice that with this one query, you get results from two different APIs:
 +
 image::datagraph-qsg-two-apis.png[Two APIs are being queried from a single query]
 +
-<1> `shippingAddress`, `total`, and `status` information is returned from the Catalyst Order API
-<1> `product` details is returned as part of the `shipmentItems` information from the Catalyst Product API
+[calloutlist]
+. `shippingAddress`, `total`, and `status` information is returned from the Catalyst Order API
+. `product` details is returned as part of the `shipmentItems` information from the Catalyst Product API
 +
 This is the fundamental utility of Anypoint DataGraph: the ability to query multiple APIs in a single request to get only the information you want.
 

--- a/modules/ROOT/pages/edit-schema.adoc
+++ b/modules/ROOT/pages/edit-schema.adoc
@@ -35,16 +35,11 @@ Refer to xref:linking.adoc[] for more information.
 If you need to edit the URL of an API that you've added to the unified schema, you can do so on the *API details* page. Refer to xref:add-api-to-unified-schema.adoc#edit-the-url-for-an-api-added-to-the-unified-schema[Edit the URL for an API Added to the Unified Schema].
 * Change the Authentication Method for an API
 +
-If you need to edit the authentication method of an API that you've added to the unified schema, you can do so on the *API details* page. Refer to xref:add-api-to-unified-schema.adoc#change-the-authentication-method-for-an-api-aded-to-the-unified-schema[Change the Authentication Method for an API Added to the Unified Schema].
+If you need to edit the authentication method of an API that you've added to the unified schema, you can do so on the *API details* page. Refer to xref:add-api-to-unified-schema.adoc#change-the-authentication-method-for-an-api-added-to-the-unified-schema[Change the Authentication Method for an API Added to the Unified Schema].
 * Configure mutual authentication (mTLS) for an API
 +
 If you need to configure mTLS for an API that you've added to the unified schema, you can do so on the *API details* page. Refer to xref:add-api-to-unified-schema.adoc#configure-mtls-for-an-api-added-to-the-unified-schema[Configure mTLS for an API Added to the Unified Schema].
 * Update an API version
 +
 After you've added an API schema to DataGraph, you can update the version of the API source any time you like. 
-Refer to xref:add-api-to-unified-schema.adoc#upate-an-api-version[Update an API Version].
-
-
-
-
-
+Refer to xref:add-api-to-unified-schema.adoc#update-an-api-version[Update an API Version].

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -68,7 +68,7 @@ To use Anypoint DataGraph, ensure you meet the following requirements:
 +
 [NOTE]
 --
-The API calls associated with your Aypoint DataGraph license refer to calls made by Anypoint DataGraph to downstream REST APIs.
+The API calls associated with your Anypoint DataGraph license refer to calls made by Anypoint DataGraph to downstream REST APIs.
 --
 
 * Your plan must allocate the correct number of vCores for your business group or organization using Anypoint DataGraph. If you haven't allocated the correct number of vCores to the environment in which you're attempting to add an API, Anypoint DataGraph raises an error message. Reapply the same changes after allocating the correct number of vCores.

--- a/modules/ROOT/pages/promote-api.adoc
+++ b/modules/ROOT/pages/promote-api.adoc
@@ -84,7 +84,7 @@ When you choose a new version of an API to promote, DataGraph lists any edits yo
 
 For any edits DataGraph can't automatically apply, you'll have the option to manually apply these edits before you complete the promotion. 
 
-Before you promote an updated API schema, you must first xref:add-api-to-unified-schema.adoc#upate-an-api-version[update the API version]:
+Before you promote an updated API schema, you must first xref:add-api-to-unified-schema.adoc#update-an-api-version[update the API version]:
 
 . Click *List of APIs added* and select the appropriate API.
 . Click *API details*.
@@ -103,4 +103,3 @@ After you apply the change, repeat Step 5 for any additional changes.
 * xref:permissions.adoc[Permissions for Anypoint DataGraph]
 * xref:resolve-conflicts.adoc[Resolve Conflicts and Merge Inconsistencies]
 * xref:troubleshoot-schemas-queries.adoc#potential-errors-when-generating-an-api-schema[]
-

--- a/modules/ROOT/pages/query-unified-schema.adoc
+++ b/modules/ROOT/pages/query-unified-schema.adoc
@@ -170,8 +170,9 @@ Those grant types properties are reflected in the UI when configuring access for
 
 image::confirm-credentials.png[Requesting access using an external client provider]
 
-<1> Both *Resource Owner Grant* and *Implicit Grant* are marked as required in the UI.
-<1> Both *Client Credentials Grant* and *Authorization Code Grant* are mutually exclusive in the UI.
+[calloutlist]
+. Both *Resource Owner Grant* and *Implicit Grant* are marked as required in the UI.
+. Both *Client Credentials Grant* and *Authorization Code Grant* are mutually exclusive in the UI.
 
 == Additional Resources
 

--- a/modules/ROOT/pages/retrieve-unified-schema.adoc
+++ b/modules/ROOT/pages/retrieve-unified-schema.adoc
@@ -2,7 +2,7 @@
 
 You can download a copy of the unified schema from the query editor or by using a third-party API client. You can download diagnostic data from the *List of APIs added* page in DataGraph.  
 
-The schema is downloaded as a `.graphl` file. Diagnostic data is downloaded as JSON files. 
+The schema is downloaded as a `.graphql` file. Diagnostic data is downloaded as JSON files. 
 
 == Download the Unified Schema from the Query Editor
 

--- a/modules/ROOT/pages/schemas.adoc
+++ b/modules/ROOT/pages/schemas.adoc
@@ -64,7 +64,7 @@ brand: String
 --
 |===
 
-Both `Order` and `Product` are different object types, each with differnt fields, that can be represented as follows:
+Both `Order` and `Product` are different object types, each with different fields, that can be represented as follows:
 
 [source]
 --

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -128,4 +128,4 @@ If the API already has a keystore or truststore, you can remove either and add n
 
 * xref:add-api-to-unified-schema.adoc[]
 * xref:promote-api.adoc[]
-* xref:add-api-to-unified-schema.adoc#change-the-authentication-method-for-an-api-aded-to-the-unified-schema[Change the Authentication Method for an API Added to the Unified Schema]
+* xref:add-api-to-unified-schema.adoc#change-the-authentication-method-for-an-api-added-to-the-unified-schema[Change the Authentication Method for an API Added to the Unified Schema]

--- a/modules/ROOT/pages/set-dlb.adoc
+++ b/modules/ROOT/pages/set-dlb.adoc
@@ -4,7 +4,7 @@ If you’re unable to use Port 8082 on a CloudHub shared load balancer, you must
 
 To set the URL, add a DLB mapping rule to the Anypoint DataGraph configuration.
 
-=== Example Mapping Rules for a DLB URL
+== Example Mapping Rules for a DLB URL
 
 Based on the way DLB mapping rules work, you must configure the *Input Path* (Input URI) and the *Output Path* (App URI) so that the final DLB URL is able to access the endpoint of the Anypoint DataGraph application, which is `/graphql`.  
 
@@ -26,7 +26,7 @@ For each index, the appropriate DLB URL is:
 * Index 2: `examplelb.lb.anypointdns.net/datagraph/graphql`
 * Index 3: `examplelb.lb.anypointdns.net/datagraph-xz082edx-1585-901xe374-d0x0/graphql`
 
-=== Prerequisites
+== Prerequisites
 
 * You must have the xref:permissions.adoc[Admin or Operator permission] for the environment in which you want to specify a DLB URL.
 * You must be able to xref:anypoint-cli::index.adoc#authentication[authenticate to] and run commands from the Anypoint CLI.
@@ -39,7 +39,7 @@ To complete this task, you:
 . Use Anypoint Runtime Manager to create a mapping rule for the DLB.
 . Use the Anypoint CLI to add the DLB configuration to Anypoint DataGraph.
 
-=== Gather Details about the DLB and Anypoint DataGraph
+== Gather Details about the DLB and Anypoint DataGraph
 
 Gather the name of your DLB and the app name for Anypoint DataGraph.
 
@@ -66,7 +66,7 @@ The expected value resembles:
 The DataGraph app name contains elements from your org ID and the environment ID.
 . Note the values for steps 3 and 4.
 
-=== Create a Mapping Rule for the DLB
+== Create a Mapping Rule for the DLB
 
 You set up the mapping rule in Runtime Manager.
 
@@ -74,7 +74,7 @@ You set up the mapping rule in Runtime Manager.
 . From the navigation menu, select *Load Balancers*.
 . Click a load balancer name, and then click a certificate name.
 +
-Ensure your load balancer has a valid, CA-signed certficate, or the browser won't connect to Anypoint DataGraph. 
+Ensure your load balancer has a valid, CA-signed certificate, or the browser won't connect to Anypoint DataGraph. 
 . In the *URL Mapping Rules* section, click *Add New Rule*.
 . Complete the fields with the following values:
 ** *Input Path* (`inputUri`): The URI that the client requests: for example, `/{app}/`
@@ -84,7 +84,7 @@ Ensure your load balancer has a valid, CA-signed certficate, or the browser won'
 +
 Anypoint DataGraph supports only HTTPS.
 
-=== Add the DLB Configuration to Anypoint DataGraph
+== Add the DLB Configuration to Anypoint DataGraph
 
 After you add the mapping rule, you configure the DLB for use with Anypoint Datagraph.
 
@@ -124,7 +124,7 @@ The CLI returns details that include the application name for the Anypoint DataG
 
 After you add this change, Anypoint DataGraph re-deploys, and you must wait for the status indicator to indicate that Anypoint DataGraph is up to date.
 
-=== Remove the DLB Configuration from Anypoint DataGraph
+== Remove the DLB Configuration from Anypoint DataGraph
 
 You can remove the DLB configuration using the following command:
 

--- a/modules/ROOT/pages/troubleshoot-query-traces.adoc
+++ b/modules/ROOT/pages/troubleshoot-query-traces.adoc
@@ -7,7 +7,7 @@ Trace results provide the following information:
 image::query-trace-details.png[Detailed view of a query trace]
 
 [calloutlist]
-. Time taken by Anypoint DataGraph to parse and validate the query @1
+. Time taken by Anypoint DataGraph to parse and validate the query
 . Total response time for the entire query
 . Errors identified during query execution
 . Lack of trace information, denoted by a fading line

--- a/modules/ROOT/pages/troubleshoot-query-traces.adoc
+++ b/modules/ROOT/pages/troubleshoot-query-traces.adoc
@@ -6,11 +6,12 @@ Trace results provide the following information:
 
 image::query-trace-details.png[Detailed view of a query trace]
 
-<1> Time taken by Anypoint DataGraph to parse and validate the query
-<2> Total response time for the entire query
-<3> Errors identified during query execution
-<4> Lack of trace information, denoted by a fading line
-<5> Duration of requests to each source API in the query
+[calloutlist]
+. Time taken by Anypoint DataGraph to parse and validate the query @1
+. Total response time for the entire query
+. Errors identified during query execution
+. Lack of trace information, denoted by a fading line
+. Duration of requests to each source API in the query
 
 == Prerequisites
 

--- a/modules/ROOT/pages/troubleshoot-schemas-queries.adoc
+++ b/modules/ROOT/pages/troubleshoot-schemas-queries.adoc
@@ -31,7 +31,7 @@ Anypoint DataGraph generates this error when it cannot load the unified schema, 
 +
 Solution: Create a dedicated load balancer (DLB) and xref:set-dlb.adoc[set its URL to configure Anypoint DataGraph to route requests through the DLB].
 
-. You've set a DLB using an invalid certficate. 
+. You've set a DLB using an invalid certificate. 
 +
 Solution: Ensure that your DLB has a valid, CA-signed certificate, or the browser won't connect to Anypoint DataGraph. 
 


### PR DESCRIPTION
ref: [W-10592565](https://gus.lightning.force.com/a07EE00000laXx7YAE)

this PR provides a number of fixes/workarounds to reduce the number of build warnings and errors.

- use [a new extension](https://github.com/RayOffiah/asciidoctor-external-callout-js) which allows us to use the `[calloutlist]` syntax for the callouts when the numbers are embedded into images
- fix the heading order for 1 page
- fix a number of typos

validated via local build that the callout numbers look the same after using the new syntax.